### PR TITLE
fix pronoun tagging, capitalization, and fix patrol death

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -2370,7 +2370,7 @@
       "general_backstory",
       "faithful"
     ],
-    "(old_name)'s eyes glimmer while l_n talks about {PRONOUN/m_c/poss} accomplishments. {PRONOUN/m_c/poss} gaze isn't focused on the leader, however, but the stars shining behind {PRONOUN/l_n/object}. As {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c, {PRONOUN/m_c/object} {VERB/m_c/wonder/wonders} if StarClan honors {PRONOUN/m_c/poss} r_h, too."
+    "(old_name)'s eyes glimmer while l_n talks about {PRONOUN/m_c/poss} accomplishments. {PRONOUN/m_c/poss/CAP} gaze isn't focused on the leader, however, but the stars shining behind {PRONOUN/l_n/object}. As {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c, {PRONOUN/m_c/subject} {VERB/m_c/wonder/wonders} if StarClan honors {PRONOUN/m_c/poss} r_h, too."
   ],
   "warrior_27": [
     [

--- a/resources/dicts/patrols/beach/med/leaf-bare.json
+++ b/resources/dicts/patrols/beach/med/leaf-bare.json
@@ -709,7 +709,13 @@
                 "text": "r_c digs and digs and digs, but eventually {PRONOUN/r_c/subject} {VERB/r_c/have/haves} to admit failure and give up the search for burdock root. The cold has leached all the heat from {PRONOUN/r_c/poss} pelt, and {PRONOUN/r_c/subject} {VERB/r_c/arrive/arrives} back at camp miserable and cold.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+				"injury": [
+                    {
+                        "cats": ["r_c"],
+                        "injuries": ["cold_injury"],
+                        "scars": ["FROSTMITT"]
+                    }
+                ],
                 "history_text": {
                     "scar": "m_c was scarred by frostbite from searching for herbs in leaf-bare."
                 }

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -93,7 +93,7 @@
             "Saw a Twoleg kit playing with a dog",
             "Saw a Twoleg kit playing with a kittypet",
             "Saw a kittypet rolling around a Twoleg garden",
-            "Is thinking about a strange Twoleg object {PRONOUN/m_c/self} saw recently",
+            "Is thinking about a strange Twoleg object {PRONOUN/m_c/subject} saw recently",
             "Is wondering what the inside of a Twoleg den looks like",
             "Is complaining about being sent on dawn patrol",
             "Is wondering if kittypet life is really so bad",


### PR DESCRIPTION
fixed wrong pronoun tag + capitalization for a warrior ceremony and a thought. fixed a medicine cat dying on patrol despite the text saying otherwise

warrior ceremony report: https://github.com/ClanGenOfficial/clangen/issues/2044
thought report: https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-1903780323

med cat wrongfully dying despite patrol text saying otherwise: 
![image](https://github.com/catphrase/clangen/assets/126827015/620c5ceb-a01b-4920-b130-817e5aa39250)
